### PR TITLE
fix: update English text labels (#32 #33)

### DIFF
--- a/src/locales/en/about.json
+++ b/src/locales/en/about.json
@@ -61,7 +61,7 @@
       "address-link": "https://maps.google.com/?q=彰化縣芬園鄉芬園村芬草路二段205號2樓",
       "phone": "+8864-9252-2313",
       "fax": "+8864-9251-0477",
-      "taxId": "Business Account Number: 90142450"
+      "taxId": "Registration Number: 90142450"
     },
     {
       "name": "Win More Environmental Protection Technology Co., Ltd",
@@ -69,7 +69,7 @@
       "address-link": "https://maps.google.com/?q=南投縣南投市自強二路17號",
       "phone": "+8864-9226-0388",
       "fax": "+8864-9226-0398",
-      "taxId": "Business Account Number: 90151719"
+      "taxId": "Registration Number: 90151719"
     },
     {
       "name": "Win Sing(Thailand) Co. Ltd",
@@ -77,14 +77,14 @@
       "address-link": "https://maps.google.com/?q=216/7 Moo.7, Hua Samrong, Plaeng Yao, Chachoengsao, 24190",
       "phone": "+663-359-0988",
       "fax": "+663-359-0288",
-      "taxId": "Business Account Number: 0105566090817"
+      "taxId": "Registration Number: 0105566090817"
     },
     {
       "name": "Win More Japan Co., Ltd",
       "address": "2-chōme-3-7 Kasugademinami, Konohana Ward, Osaka, 554-0023",
       "address-link": "https://maps.google.com/?q=〒554-0023+大阪府大阪市此花区春日出南2-3-7",
       "phone": "+81-50-3592-6022",
-      "taxId": "Business Account Number: 8120001281826"
+      "taxId": "Registration Number: 8120001281826"
     }
   ]
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -4,7 +4,7 @@
   "ceo-message": "CEO Message",
   "company-profile": "Company Profile",
   "history": "History",
-  "affiliates": "Group Companies",
+  "affiliates": "Affiliates",
   "business": "Business",
   "business-content": "Business Contents",
   "sdgs": "SDGs",

--- a/src/locales/ja/about.json
+++ b/src/locales/ja/about.json
@@ -62,7 +62,7 @@
       "address-link": "https://maps.google.com/?q=彰化縣芬園鄉芬園村芬草路二段205號2樓",
       "phone": "+8864-9252-2313",
       "fax": "+8864-9251-0477",
-      "taxId": "Business Account Number: 90142450"
+      "taxId": "Registration Number: 90142450"
     },
     {
       "name": "Win More Environmental Protection Technology Co., Ltd",
@@ -70,7 +70,7 @@
       "address-link": "https://maps.google.com/?q=南投縣南投市自強二路17號",
       "phone": "+8864-9226-0388",
       "fax": "+8864-9226-0398",
-      "taxId": "Business Account Number: 90151719"
+      "taxId": "Registration Number: 90151719"
     },
     {
       "name": "Win Sing(Thailand) Co. Ltd",
@@ -78,7 +78,7 @@
       "address-link": "https://maps.google.com/?q=216/7 Moo.7, Hua Samrong, Plaeng Yao, Chachoengsao, 24190",
       "phone": "+663-359-0988",
       "fax": "+663-359-0288",
-      "taxId": "Business Account Number: 0105566090817"
+      "taxId": "Registration Number: 0105566090817"
     },
     {
       "name": "允貿日本株式会社",


### PR DESCRIPTION
## Summary

- **#33** — 頁首選單與段落標題：`Group Companies` → `Affiliates`
- **#32** — 英文/日文統編標籤：`Business Account Number` → `Registration Number`（`en` 共 5 處、`ja` 共 3 處）

## Files Changed

- `src/locales/en/translation.json` — affiliates 標題
- `src/locales/en/about.json` — companyInfoTitle.taxId + 4 筆 affiliate taxId
- `src/locales/ja/about.json` — 3 筆 affiliate taxId

Closes #32
Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)