### PR TITLE
fix(about): update affiliate taxId labels (#36)

### DIFF
--- a/src/locales/en/about.json
+++ b/src/locales/en/about.json
@@ -61,7 +61,7 @@
       "address-link": "https://maps.google.com/?q=彰化縣芬園鄉芬園村芬草路二段205號2樓",
       "phone": "+8864-9252-2313",
       "fax": "+8864-9251-0477",
-      "taxId": "Registration Number: 90142450"
+      "taxId": "Tax Identification Number: 90142450"
     },
     {
       "name": "Win More Environmental Protection Technology Co., Ltd",
@@ -69,7 +69,7 @@
       "address-link": "https://maps.google.com/?q=南投縣南投市自強二路17號",
       "phone": "+8864-9226-0388",
       "fax": "+8864-9226-0398",
-      "taxId": "Registration Number: 90151719"
+      "taxId": "Tax Identification Number: 90151719"
     },
     {
       "name": "Win Sing(Thailand) Co. Ltd",
@@ -77,7 +77,7 @@
       "address-link": "https://maps.google.com/?q=216/7 Moo.7, Hua Samrong, Plaeng Yao, Chachoengsao, 24190",
       "phone": "+663-359-0988",
       "fax": "+663-359-0288",
-      "taxId": "Registration Number: 0105566090817"
+      "taxId": "Tax Identification Number: 0105566090817"
     },
     {
       "name": "Win More Japan Co., Ltd",

--- a/src/locales/ja/about.json
+++ b/src/locales/ja/about.json
@@ -62,7 +62,7 @@
       "address-link": "https://maps.google.com/?q=彰化縣芬園鄉芬園村芬草路二段205號2樓",
       "phone": "+8864-9252-2313",
       "fax": "+8864-9251-0477",
-      "taxId": "Registration Number: 90142450"
+      "taxId": "Tax Identification Number: 90142450"
     },
     {
       "name": "Win More Environmental Protection Technology Co., Ltd",
@@ -70,7 +70,7 @@
       "address-link": "https://maps.google.com/?q=南投縣南投市自強二路17號",
       "phone": "+8864-9226-0388",
       "fax": "+8864-9226-0398",
-      "taxId": "Registration Number: 90151719"
+      "taxId": "Tax Identification Number: 90151719"
     },
     {
       "name": "Win Sing(Thailand) Co. Ltd",
@@ -78,7 +78,7 @@
       "address-link": "https://maps.google.com/?q=216/7 Moo.7, Hua Samrong, Plaeng Yao, Chachoengsao, 24190",
       "phone": "+663-359-0988",
       "fax": "+663-359-0288",
-      "taxId": "Registration Number: 0105566090817"
+      "taxId": "Tax Identification Number: 0105566090817"
     },
     {
       "name": "允貿日本株式会社",

--- a/src/locales/zh-TW/about.json
+++ b/src/locales/zh-TW/about.json
@@ -78,7 +78,7 @@
       "address-link": "https://maps.google.com/?q=216/7 Moo.7, Hua Samrong, Plaeng Yao, Chachoengsao, 24190",
       "phone": "+663-359-0988",
       "fax": "+663-359-0288",
-      "taxId": "統一編號: 0105566090817"
+      "taxId": "稅務識別號碼: 0105566090817"
     },
     {
       "name": "允貿日本株式会社",


### PR DESCRIPTION
## Summary

- Taiwan affiliates (EN/JA): `Registration Number` → `Tax Identification Number`
- Thailand affiliate (ZH): `統一編號` → `稅務識別號碼`
- Thailand affiliate (EN/JA): `Registration Number` → `Tax Identification Number`

Closes #36

## Test plan

- [ ] 關於頁面「關係企業」區塊：台灣公司（允興投資、允貿環保）英文、日文顯示 Tax Identification Number
- [ ] 關於頁面「關係企業」區塊：泰國公司（允興泰國）中文顯示 稅務識別號碼
- [ ] 關於頁面「關係企業」區塊：泰國公司（允興泰國）英文、日文顯示 Tax Identification Number

🤖 Generated with [Claude Code](https://claude.com/claude-code)